### PR TITLE
Add RHEL support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 
-- name: "Add epel-release repository"
+- name: "Add epel-release repository (RHEL)"
+  yum:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    state: "present"
+  when: ansible_distribution == 'RedHat'
+
+- name: "Add epel-release repository (CentOS)"
   yum:
     name: "epel-release"
     state: "latest"
@@ -9,7 +15,7 @@
 - name: Install the nginx packages
   yum: name={{ item }} state=present
   with_items: "{{ redhat_pkg }}"
-  when: ansible_distribution == 'CentOS'
+  when: ansible_os_family == 'RedHat'
   tags: [packages,nginx]
 
 - name: Install the nginx packages


### PR DESCRIPTION
This commit includes RHEL support for this role. A new task has been added that
installs the epel-release package from the fedora homepage for RHEL.

Connects to https://github.com/artefactual-labs/ansible-nginx/issues/4 and https://github.com/archivematica/Issues/issues/137