### PR TITLE
Update deprecated options

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,8 +79,8 @@
   shell: nginx -t
   register: result
   changed_when: "result.rc != 0"
-  always_run: yes
-  tags: [configuration,nginx]
+  check_mode: no
+  tags: [configuration,nginx,always]
 
 - name: Start the nginx service
   service: name=nginx state=started enabled=yes


### PR DESCRIPTION
always_run was deprecated long ago:

https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.6.html

as the alternative check_mode is available since ansible 2.1, this change should be
unnoticeable