### PR TITLE
python3: add list filter to keys()

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,33 +49,33 @@
 
 - name: Ensure auth_basic files created
   template: src=auth_basic.j2 dest=/etc/nginx/auth_basic/{{ item }} owner=root group={{nginx_group}} mode=0750
-  with_items: "{{ nginx_auth_basic_files.keys() }}"
+  with_items: "{{ nginx_auth_basic_files.keys() | list }}"
   tags: [configuration,nginx]
 
 - name: Create the configurations for sites
   template: src=site.conf.j2 dest=/etc/nginx/sites-available/{{ item }}.conf
-  with_items: "{{ nginx_sites.keys() }}"
+  with_items: "{{ nginx_sites.keys() | list }}"
   notify:
    - Reload nginx
   tags: [configuration,nginx]
 
 - name: Create links for sites-enabled
   file: state=link src=/etc/nginx/sites-available/{{ item }}.conf dest=/etc/nginx/sites-enabled/{{ item }}.conf
-  with_items: "{{ nginx_sites.keys() }}"
+  with_items: "{{ nginx_sites.keys() | list }}"
   notify:
    - Reload nginx
   tags: [configuration,nginx]
 
 - name: Disable the default site
   file: path=/etc/nginx/sites-enabled/default state=absent
-  when: nginx_sites.keys() != []
+  when: nginx_sites.keys() | list  != []
   notify:
    - Reload nginx
   tags: [configuration,nginx]
 
 - name: Create the configurations for independante config file
   template: src=config.conf.j2 dest=/etc/nginx/conf.d/{{ item }}.conf
-  with_items: "{{ nginx_configs.keys() }}"
+  with_items: "{{ nginx_configs.keys() | list  }}"
   notify:
    - Reload nginx
   tags: [configuration,nginx]


### PR DESCRIPTION
Add list filter, for python 3 compatibility
(https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#pb-py-compat-dict-views)