### PR TITLE
Update 20.04 package dependency

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,15 @@
     name: "{{ ubuntu_pkg }}"
     state: "present"
     update_cache: yes
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" and ansible_distribution_version is version_compare('18.04', '<=')
+  tags: [packages,nginx]
+
+- name: Install the nginx packages
+  apt:
+    name: "{{ ubuntu_focal_pkg }}"
+    state: "present"
+    update_cache: yes
+  when: ansible_os_family == "Debian" and ansible_distribution_version is version_compare('20.04', '>=')
   tags: [packages,nginx]
 
 - name: Create the directories for site specific configurations

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,9 @@ ubuntu_pkg:
   - python-passlib
   - python-selinux
   - nginx
+
+ubuntu_focal_pkg:
+  - python3-passlib
+  - python3-selinux
+  - python-is-python3
+  - nginx


### PR DESCRIPTION
The package 'python-selinux' is not available in Ubuntu 20.04.

Updated to install python3 equivalents when OS is Ubuntu 20.04.