### PR TITLE
Add rate request limit for crawlers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,46 @@ nginx_http_params:
   - error_log "{{ nginx_log_dir }}/error.log"
   - server_tokens off
   - types_hash_max_size 2048
+  - |
+    map $http_user_agent $isbot_ua {
+              default 0;
+              # Regex from: https://observablehq.com/@hugodf/crawler-regex
+              # Needs to escape black spaces and split in several regex, it can help:
+              # Copy regex to file and run: cat regex  | sed 's/\ /\\\ /g' | sed -e 's/.\{300\}/&\n\n/g' > regex_fixed
+              # Curl and wget removed
+              ~*(Googlebot\/|Googlebot-Mobile|Googlebot-Image|Googlebot-News|Googlebot-Video|AdsBot-Google([^-]|$)|AdsBot-Google-Mobile|Feedfetcher-Google|Mediapartners-Google|Mediapartners\ \(Googlebot\)|APIs-Google|bingbot|Slurp|LinkedInBot|Python-urllib|python-requests|libwww-perl|httpunit|nutch|Go-http-client)  1;
+              ~*(phpcrawl|msnbot|jyxobot|FAST-WebCrawler|FAST\ Enterprise\ Crawler|BIGLOTRON|Teoma|convera|seekbot|Gigabot|Gigablast|exabot|ia_archiver|GingerCrawler|webmon\ |HTTrack|grub.org|UsineNouvelleCrawler|antibot|netresearchserver|speedy|fluffy|findlink|msrbot|panscient|yacybot|AISearchBot|ips-agent)  1;
+              ~*(tagoobot|MJ12bot|woriobot|yanga|buzzbot|mlbot|YandexBot|YandexImages|YandexAccessibilityBot|YandexMobileBot|purebot|Linguee\ Bot|CyberPatrol|voilabot|Baiduspider|citeseerxbot|spbot|twengabot|postrank|TurnitinBot|scribdbot|page2rss|sitebot|linkdex|Adidxbot|ezooms|dotbot|Mail.RU_Bot|discobot|heritrix) 1;
+              ~*(findthatfile|europarchive.org|NerdByNature.Bot|sistrix\ crawler|Ahrefs(Bot|SiteAudit)|fuelbot|CrunchBot|IndeedBot|mappydata|woobot|ZoominfoBot|PrivacyAwareBot|Multiviewbot|SWIMGBot|Grobbot|eright|Apercite|semanticbot|Aboundex|domaincrawler|wbsearchbot|summify|CCBot|edisterbot|seznambot|ec2linkfinder) 1;
+              ~*(gslfbot|aiHitBot|intelium_bot|facebookexternalhit|Yeti|RetrevoPageAnalyzer|lb-spider|Sogou|lssbot|careerbot|wotbox|wocbot|ichiro|DuckDuckBot|lssrocketcrawler|drupact|webcompanycrawler|acoonbot|openindexspider|gnam\ gnam\ spider|web-archive-net.com.bot|backlinkcrawler|coccoc|integromedb|content\ crawler\ spider)  1;
+              ~*(toplistbot|it2media-domain-crawler|ip-web-crawler.com|siteexplorer.info|elisabot|proximic|changedetection|arabot|WeSEE:Search|niki-bot|CrystalSemanticsBot|rogerbot|360Spider|psbot|InterfaxScanBot|CC\ Metadata\ Scaper|g00g1e.net|GrapeshotCrawler|urlappendbot|brainobot|fr-crawler|binlar)  1;
+              ~*(SimpleCrawler|Twitterbot|cXensebot|smtbot|bnf.fr_bot|A6-Indexer|ADmantX|Facebot|OrangeBot\/|memorybot|AdvBot|MegaIndex|SemanticScholarBot|ltx71|nerdybot|xovibot|BUbiNG|Qwantify|archive.org_bot|Applebot|TweetmemeBot|crawler4j|findxbot|S[eE][mM]rushBot|yoozBot|lipperhey|Y!J|Domain\ Re-Animator\ Bot)  1;
+              ~*(AddThis|Screaming\ Frog\ SEO\ Spider|MetaURI|Scrapy|Livelap[bB]ot|OpenHoseBot|CapsuleChecker|collection@infegy.com|IstellaBot|DeuSu\/|betaBot|Cliqzbot\/|MojeekBot\/|netEstate\ NE\ Crawler|SafeSearch\ microdata\ crawler|Gluten\ Free\ Crawler\/|Sonic|Sysomos|Trove|deadlinkchecker|Slack-ImgProxy|Embedly)  1;
+              ~*(RankActiveLinkBot|iskanie|SafeDNSBot|SkypeUriPreview|Veoozbot|Slackbot|redditbot|datagnionbot|Google-Adwords-Instant|adbeat_bot|WhatsApp|contxbot|pinterest.com.bot|electricmonk|GarlikCrawler|BingPreview\/|vebidoobot|FemtosearchBot|Yahoo\ Link\ Preview|MetaJobBot|DomainStatsBot|mindUpBot)  1;
+              ~*(Jugendschutzprogramm-Crawler|Xenu\ Link\ Sleuth|Pcore-HTTP|moatbot|KosmioBot|pingdom|AppInsights|PhantomJS|Gowikibot|PiplBot|Discordbot|TelegramBot|Jetslide|newsharecounts|James\ BOT|Bark[rR]owler|TinEye|SocialRankIOBot|trendictionbot|Ocarinabot|epicbot|Primalbot|DuckDuckGo-Favicons-Bot|GnowitNewsbot)  1;
+              ~*(Leikibot|LinkArchiver|YaK\/|PaperLiBot|Digg\ Deeper|dcrawl|Snacktory|AndersPinkBot|Fyrebot|EveryoneSocialBot|Mediatoolkitbot|Luminator-robots|ExtLinksBot|SurveyBot|NING\/|okhttp|Nuzzel|omgili|PocketParser|YisouSpider|um-LN|ToutiaoSpider|MuckRack|Jamie's\ Spider|AHC\/|NetcraftSurveyAgent|Laserlikebot)  1;
+              ~*(^Apache-HttpClient|AppEngine-Google|Jetty|Upflow|Thinklab|Traackr.com|Twurly|Mastodon|http_get|DnyzBot|botify|007ac9\ Crawler|BehloolBot|BrandVerity|check_http|BDCbot|ZumBot|EZID|ICC-Crawler|ArchiveBot|^LCC\ |filterdb.iss.net\/crawler|BLP_bbot|BomboraBot|Buck\/|Companybook-Crawler|Genieo|magpie-crawler)  1;
+              ~*(MeltwaterNews|Moreover|newspaper\/|ScoutJet|(^|\ )sentry\/|StorygizeBot|UptimeRobot|OutclicksBot|seoscanners|Hatena|Google\ Web\ Preview|MauiBot|AlphaBot|SBL-BOT|IAS\ crawler|adscanner|Netvibes|acapbot|Baidu-YunGuanCe|bitlybot|blogmuraBot|Bot.AraTurka.com|bot-pge.chlooe.com|BoxcarBot|BTWebClient)  1;
+              ~*(ContextAd\ Bot|Digincore\ bot|Disqus|Feedly|Fetch\/|Fever|Flamingo_SearchEngine|FlipboardProxy|g2reader-bot|G2\ Web\ Services|imrbot|K7MLWCBot|Kemvibot|Landau-Media-Spider|linkapediabot|vkShare|Siteimprove.com|BLEXBot\/|DareBoost|ZuperlistBot\/|Miniflux\/|Feedspot|Diffbot\/|SEOkicks|tracemyfile)  1;
+              ~*(Nimbostratus-Bot|zgrab|PR-CY.RU|AdsTxtCrawler|Datafeedwatch|TangibleeBot|google-xrawler|axios|Amazon\ CloudFront|Pulsepoint|CloudFlare-AlwaysOnline|Google-Structured-Data-Testing-Tool|WordupInfoSearch|WebDataStats|HttpUrlConnection|Seekport\ Crawler|ZoomBot|VelenPublicWebCrawler|MoodleBot)  1;
+              ~*(jpg-newsbot|outbrain|W3C_Validator|Validator\.nu|W3C-checklink|W3C-mobileOK|W3C_I18n-Checker|FeedValidator|W3C_CSS_Validator|W3C_Unicorn|Google-PhysicalWeb|Blackboard|ICBot\/|BazQux|Twingly|Rivva|Experibot|awesomecrawler|Dataprovider.com|GroupHigh\/|theoldreader.com|AnyEvent|Uptimebot\.org|Nmap\ Scripting\ Engine)  1;
+              ~*(2ip.ru|Clickagy|Caliperbot|MBCrawler|online-webceo-bot|B2B\ Bot|AddSearchBot|Google\ Favicon|HubSpot|Chrome-Lighthouse|HeadlessChrome|CheckMarkNetwork\/|www\.uptime\.com|Streamline3Bot\/|serpstatbot\/|MixnodeCache\/|SimpleScraper|RSSingBot|Jooblebot|fedoraplanet|Friendica|NextCloud|Tiny\Tiny\ RSS)  1;
+              ~*(RegionStuttgartBot|Bytespider|Datanyze|Google-Site-Verification|TrendsmapResolver|tweetedtimes|NTENTbot|Gwene|SimplePie|SearchAtlas|Superfeedr|feedbot|UT-Dorkbot|Amazonbot|SerendeputyBot|Eyeotabot|officestorebot|Neticle\ Crawler|SurdotlyBot|LinkisBot|AwarioSmartBot|AwarioRssBot|RyteBot|FreeWebMonitoring\ SiteChecker)  1;
+              ~*(AspiegelBot|NAVER\ Blog\ Rssbot|zenback\ bot|SentiBot|Domains\ Project\/|Pandalytics|VKRobot|bidswitchbot|tigerbot|NIXStatsbot|Atom\ Feed\ Robot|Curebot|PagePeeker\/|Vigil\/|rssbot\/|startmebot\/|JobboerseBot|seewithkids|NINJA\ bot|Cutbot|BublupBot|BrandONbot|RidderBot|YandexMetrika)  1;
+              ~*(YandexTurbo|YandexImageResizer|YandexVideoParser|Taboolabot|Dubbotbot|FindITAnswersbot|infoobot|Refindbot|BlogTraffic\/\d\.\d+\ Feed-Fetcher|SeobilityBot|Cincraw|Dragonbot|VoluumDSP-content-bot|FreshRSS|BitBot|PetalBot|SemrushBot) 1;
+            }
+            map $isbot_ua $limit_bot {
+              0       "";
+              # Use $http_x_forwarded_for instead of $binary_remote_addr when using reverse proxy
+              1       $binary_remote_addr;
+            }
+            limit_req_zone $limit_bot zone=bots:10m rate=1r/m
+  # Use $http_x_forwarded_for instead of $binary_remote_addr when using reverse proxy
+  - limit_req_zone $binary_remote_addr zone=one:50m rate=50r/s
+  - limit_req zone=bots burst=2 nodelay
+  - limit_req zone=one burst=15 nodelay
+  - limit_req_status 429
+
 
 nginx_sites:
   default:


### PR DESCRIPTION
Hi @mamedin - as discussed, this is a first pass at adding the crawler rate limit code (based on as go into epic sites currently, and others) right into the nginx role. 

I have made the change of

> - limit_req_zone $binary_remote_addr zone=one:50m rate=100r/s

for shared hosting sites to

> - limit_req_zone $binary_remote_addr zone=one:50m rate=50r/s

Please have a look and see if there are other aspects you would now tweak / add, or any thoughts or concerns.