### PR TITLE
Add RHEL EPEL GPG key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 - name: Configure repositories
   block:
+    - name: "Add epel-release GPG key (RHEL)"
+      rpm_key:
+        state: present
+        key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9"
+      when: ansible_distribution == 'RedHat'
     - name: "Add epel-release repository (RHEL)"
       yum:
         name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version|int }}.noarch.rpm"


### PR DESCRIPTION
Add EPEL GPG key. It was failing in RHEL9 when adding epel-release package:

```
"Failed to validate GPG signature for epel-release-9-7.el9.noarch: Public key for epel-release-latest-9.noarchgwny9een.rpm is not installed"}
```